### PR TITLE
Allow passing in multiple input files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rootproject/root:6.24.00-ubuntu20.04
+FROM rootproject/root:6.24.02-ubuntu20.04
 COPY macros /root/macros/
 COPY util /root/util/
 WORKDIR /root/util

--- a/macros/benchmark1.C
+++ b/macros/benchmark1.C
@@ -1,7 +1,7 @@
 #include "ROOT/RDataFrame.hxx"
 #include "TCanvas.h"
 
-void benchmark1(const std::string input = "root://eospublic.cern.ch//eos/root-eos/benchmark/Run2012B_SingleMu.root",
+void benchmark1(const std::vector<std::string> input = {"root://eospublic.cern.ch//eos/root-eos/benchmark/Run2012B_SingleMu.root"},
                 const bool multithreading = true) {
     if (multithreading) ROOT::EnableImplicitMT();
 

--- a/macros/benchmark2.C
+++ b/macros/benchmark2.C
@@ -1,7 +1,7 @@
 #include "ROOT/RDataFrame.hxx"
 #include "TCanvas.h"
 
-void benchmark2(const std::string input = "root://eospublic.cern.ch//eos/root-eos/benchmark/Run2012B_SingleMu.root",
+void benchmark2(const std::vector<std::string> input = {"root://eospublic.cern.ch//eos/root-eos/benchmark/Run2012B_SingleMu.root"},
                 const bool multithreading = true) {
     if (multithreading) ROOT::EnableImplicitMT();
 

--- a/macros/benchmark3.C
+++ b/macros/benchmark3.C
@@ -1,7 +1,7 @@
 #include "ROOT/RDataFrame.hxx"
 #include "TCanvas.h"
 
-void benchmark3(const std::string input = "root://eospublic.cern.ch//eos/root-eos/benchmark/Run2012B_SingleMu.root",
+void benchmark3(const std::vector<std::string> input = {"root://eospublic.cern.ch//eos/root-eos/benchmark/Run2012B_SingleMu.root"},
                 const bool multithreading = true) {
     if (multithreading) ROOT::EnableImplicitMT();
 

--- a/macros/benchmark4.C
+++ b/macros/benchmark4.C
@@ -1,7 +1,7 @@
 #include "ROOT/RDataFrame.hxx"
 #include "TCanvas.h"
 
-void benchmark4(const std::string input = "root://eospublic.cern.ch//eos/root-eos/benchmark/Run2012B_SingleMu.root",
+void benchmark4(const std::vector<std::string> input = {"root://eospublic.cern.ch//eos/root-eos/benchmark/Run2012B_SingleMu.root"},
                 const bool multithreading = true) {
     if (multithreading) ROOT::EnableImplicitMT();
 

--- a/macros/benchmark5.C
+++ b/macros/benchmark5.C
@@ -24,7 +24,7 @@ ROOT::RVec<float> get_dimuon_mass(const ROOT::RVec<ROOT::Math::PtEtaPhiMVector> 
     return dimuon_mass;
 }
 
-void benchmark5(const std::string input = "root://eospublic.cern.ch//eos/root-eos/benchmark/Run2012B_SingleMu.root",
+void benchmark5(const std::vector<std::string> input = {"root://eospublic.cern.ch//eos/root-eos/benchmark/Run2012B_SingleMu.root"},
                 const bool multithreading = true) {
     if (multithreading) ROOT::EnableImplicitMT();
 

--- a/macros/benchmark6.C
+++ b/macros/benchmark6.C
@@ -26,7 +26,7 @@ ROOT::RVec<float> get_mass(const ROOT::RVec<ROOT::Math::PtEtaPhiMVector> &p4) {
     return ROOT::VecOps::Map(p4, [](const ROOT::Math::PtEtaPhiMVector &p4){ return p4.mass(); });
 }
 
-void benchmark6(const std::string input = "root://eospublic.cern.ch//eos/root-eos/benchmark/Run2012B_SingleMu.root",
+void benchmark6(const std::vector<std::string> input = {"root://eospublic.cern.ch//eos/root-eos/benchmark/Run2012B_SingleMu.root"},
                 const bool multithreading = true) {
     if (multithreading) ROOT::EnableImplicitMT();
 

--- a/macros/benchmark6a.C
+++ b/macros/benchmark6a.C
@@ -26,7 +26,7 @@ ROOT::RVec<float> get_mass(const ROOT::RVec<ROOT::Math::PtEtaPhiMVector> &p4) {
     return ROOT::VecOps::Map(p4, [](const ROOT::Math::PtEtaPhiMVector &p4){ return p4.mass(); });
 }
 
-void benchmark6a(const std::string input = "root://eospublic.cern.ch//eos/root-eos/benchmark/Run2012B_SingleMu.root",
+void benchmark6a(const std::vector<std::string> input = {"root://eospublic.cern.ch//eos/root-eos/benchmark/Run2012B_SingleMu.root"},
                 const bool multithreading = true) {
     if (multithreading) ROOT::EnableImplicitMT();
 

--- a/macros/benchmark6b.C
+++ b/macros/benchmark6b.C
@@ -26,7 +26,7 @@ ROOT::RVec<float> get_mass(const ROOT::RVec<ROOT::Math::PtEtaPhiMVector> &p4) {
     return ROOT::VecOps::Map(p4, [](const ROOT::Math::PtEtaPhiMVector &p4){ return p4.mass(); });
 }
 
-void benchmark6b(const std::string input = "root://eospublic.cern.ch//eos/root-eos/benchmark/Run2012B_SingleMu.root",
+void benchmark6b(const std::vector<std::string> input = {"root://eospublic.cern.ch//eos/root-eos/benchmark/Run2012B_SingleMu.root"},
                 const bool multithreading = true) {
     if (multithreading) ROOT::EnableImplicitMT();
 

--- a/macros/benchmark7.C
+++ b/macros/benchmark7.C
@@ -24,7 +24,7 @@ ROOT::RVec<int> get_jet_lepton_isolation(const ROOT::RVec<float> &jet_eta,
 }
 
 
-void benchmark7(const std::string input = "root://eospublic.cern.ch//eos/root-eos/benchmark/Run2012B_SingleMu.root",
+void benchmark7(const std::vector<std::string> input = {"root://eospublic.cern.ch//eos/root-eos/benchmark/Run2012B_SingleMu.root"},
                 const bool multithreading = true) {
     if (multithreading) ROOT::EnableImplicitMT();
 

--- a/macros/benchmark8.C
+++ b/macros/benchmark8.C
@@ -36,7 +36,7 @@ ROOT::RVec<float> get_dilepton_mass(const ROOT::RVec<ROOT::Math::PtEtaPhiMVector
     return dilepton_mass;
 }
 
-void benchmark8(const std::string input = "root://eospublic.cern.ch//eos/root-eos/benchmark/Run2012B_SingleMu.root",
+void benchmark8(const std::vector<std::string> input = {"root://eospublic.cern.ch//eos/root-eos/benchmark/Run2012B_SingleMu.root"},
                 const bool multithreading = true) {
     if (multithreading) ROOT::EnableImplicitMT();
 

--- a/util/run_benchmark.sh
+++ b/util/run_benchmark.sh
@@ -37,17 +37,17 @@ do
         shift # past value
         ;;
       -b|--benchmark-id)
-        BENCHMARK_ID="$2"
+        BENCHMARK_ID="$(read_value "$@")" || exit 1
         shift # past argument
         shift # past value
         ;;
       -m|--enable-multithreading)
-        ENABLE_MULTITHREADING="$2"
+        ENABLE_MULTITHREADING="$(read_value "$@")" || exit 1
         shift # past argument
         shift # past value
         ;;
       -o|--enable-optimizations)
-        ENABLE_OPTIMIZATIONS="$2"
+        ENABLE_OPTIMIZATIONS="$(read_value "$@")" || exit 1
         shift # past argument
         shift # past value
         ;;
@@ -61,6 +61,13 @@ do
         ;;
     esac
 done
+
+if [ -z "$BENCHMARK_ID" ]
+then
+	echo "Benchmark ID must be specified." >&2
+	print_usage >&2
+	exit 1
+fi
 
 if $VERBOSE
 then

--- a/util/run_benchmark.sh
+++ b/util/run_benchmark.sh
@@ -1,36 +1,96 @@
 #!/bin/bash
 
-if [ "$1" == "-n" ]
+# Default parameter values
+NUM_TRIALS=1
+ENABLE_MULTITHREADING=true
+ENABLE_OPTIMIZATIONS=true
+VERBOSE=false
+INPUT_FILES=()
+
+function print_usage() {
+    echo "Usage: $0 -b <benchmark ID> [-n <#trials>] [-m <multithreading>] [-o <optimizations>] [input file]"
+}
+
+function read_value() {
+    if [[ $# -lt 2 ]]
+    then
+        echo "Argument $1 requires a value." >&2
+        print_usage >&2
+        exit 1
+    fi
+    printf "%s" "$2"
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+
+    case $key in
+      -h|--help)
+        print_usage
+        exit
+        ;;
+      -n|--num-trials)
+        NUM_TRIALS="$(read_value "$@")" || exit 1
+        shift # past argument
+        shift # past value
+        ;;
+      -b|--benchmark-id)
+        BENCHMARK_ID="$2"
+        shift # past argument
+        shift # past value
+        ;;
+      -m|--enable-multithreading)
+        ENABLE_MULTITHREADING="$2"
+        shift # past argument
+        shift # past value
+        ;;
+      -o|--enable-optimizations)
+        ENABLE_OPTIMIZATIONS="$2"
+        shift # past argument
+        shift # past value
+        ;;
+      -v|--verbose)
+        VERBOSE=true
+        shift # past argument
+        ;;
+      *)
+        INPUT_FILES=("$@")
+        break
+        ;;
+    esac
+done
+
+if $VERBOSE
 then
-	n="$2"
-        n=$((n+0))
-	shift 2
-else
-	n=1
+    echo "Num trials: $NUM_TRIALS"
+    echo "Benchmark ID: $BENCHMARK_ID"
+    echo "Enable multi-threading: $ENABLE_MULTITHREADING"
+    echo "Enable optimizations: $ENABLE_OPTIMIZATIONS"
+    echo "Files: ${INPUT_FILES[@]}"
 fi
 
-if [ "$n" -lt 1 ] || [ -z "$1" ]
-then
-	echo "usage: $0 [-n <number of trials>] <benchmark number> [input file] [multithreading] [optimizations]"
-	exit 1
-fi
-
-macro_name="benchmark$1"
+# Assemble call to macro
+macro_name="benchmark$BENCHMARK_ID"
 macro_path="$(dirname $0)/../macros/$macro_name.C"
 
-if [ $# -lt 2 ]
+if [[ ${#INPUT_FILES[@]} -eq 0 && "$ENABLE_MULTITHREADING" != "true" ]]
 then
-	macro_call="$macro_name()"
-elif [ $# -lt 3 ]
+    echo "Cannot disable multi-threading if no explit input files are given." >&2
+    exit 1
+elif [[ ${#INPUT_FILES[@]} -eq 0 ]]
 then
-	macro_call="$macro_name(\"$2\")"
+    macro_call="$macro_name()"
 else
-	macro_call="$macro_name(\"$2\", $3)"
+    files_arg="$(for f in ${INPUT_FILES[@]}; do echo "\"$f\""; done | paste -s -d, -)"
+    macro_call="$macro_name({$files_arg}, $ENABLE_MULTITHREADING)"
 fi
 
+# Assemble ROOT options
 root_options=('-b' '-l')
 
-if [ -z "$4" ] || [ "$4" == "true" ]
+if [[ $ENABLE_OPTIMIZATIONS ]]
 then
 	root_options+=('-e' '.L /opt/root/lib/libROOTDataFrame.so' '-e' ".L $macro_path+O")
 else
@@ -39,7 +99,7 @@ fi
 
 root "${root_options[@]}" <<EOF
 try {
-	for (auto i = 0; i < $n; ++i) {
+	for (auto i = 0; i < $NUM_TRIALS; ++i) {
 		auto start = std::chrono::steady_clock::now();
 		$macro_call;
 		auto stop = std::chrono::steady_clock::now();


### PR DESCRIPTION
This should make it easier to scale up to larger, potentially replicated data sets: we can give in a list of input files that are (1) either all different, (2) copies of the same file with different names, (3) the same file with the same name. Note that I overhauled the parsing of command line arguments for that purpose.